### PR TITLE
Added scrollable slider

### DIFF
--- a/MultiSoundChanger.xcodeproj/project.pbxproj
+++ b/MultiSoundChanger.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4743EFAB1E91493B0032F5AA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4743EFAA1E91493B0032F5AA /* AppDelegate.swift */; };
 		6985C6FE251951F8003C2FDB /* OSD.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6985C6FD251951F8003C2FDB /* OSD.framework */; };
+		D914CAC22698034D00FB55D2 /* ScrollableSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D914CAC12698034D00FB55D2 /* ScrollableSlider.swift */; };
 		E4FFDC0757FD125F92CC0F62 /* Pods_MultiSoundChanger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C34C05E9BD81D579A0C4957 /* Pods_MultiSoundChanger.framework */; };
 		F312C54E25B3741C00205846 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F373D8C02561D24600642274 /* Main.storyboard */; };
 		F312C55025B3742200205846 /* Volume.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F373D8BC2561D22000642274 /* Volume.storyboard */; };
@@ -36,6 +37,7 @@
 		6985C6FD251951F8003C2FDB /* OSD.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OSD.framework; sourceTree = "<group>"; };
 		6FD0ED04AFD1CC1242C9B3B3 /* Pods-MultiSoundChanger.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MultiSoundChanger.debug.xcconfig"; path = "Target Support Files/Pods-MultiSoundChanger/Pods-MultiSoundChanger.debug.xcconfig"; sourceTree = "<group>"; };
 		D184B2CD842B856AFFE7DF7E /* Pods-MultiSoundChanger.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MultiSoundChanger.release.xcconfig"; path = "Target Support Files/Pods-MultiSoundChanger/Pods-MultiSoundChanger.release.xcconfig"; sourceTree = "<group>"; };
+		D914CAC12698034D00FB55D2 /* ScrollableSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableSlider.swift; sourceTree = "<group>"; };
 		F3433FCA25B36E16009AAE86 /* Images.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Images.swift; sourceTree = "<group>"; };
 		F373D8B02561D1A600642274 /* StatusBarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusBarController.swift; sourceTree = "<group>"; };
 		F373D8B12561D1A600642274 /* AudioManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioManager.swift; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 			children = (
 				F373D8BC2561D22000642274 /* Volume.storyboard */,
 				F373D8BD2561D22000642274 /* VolumeViewController.swift */,
+				D914CAC12698034D00FB55D2 /* ScrollableSlider.swift */,
 			);
 			path = Volume;
 			sourceTree = "<group>";
@@ -363,6 +366,7 @@
 				F373D8C82561D2B000642274 /* Extensions.swift in Sources */,
 				F392597C2631ACE700B7AD62 /* Runner.swift in Sources */,
 				F3433FCB25B36E16009AAE86 /* Images.swift in Sources */,
+				D914CAC22698034D00FB55D2 /* ScrollableSlider.swift in Sources */,
 				F3925975262F2B8000B7AD62 /* ApplicationController.swift in Sources */,
 				F373D8C62561D2A600642274 /* Audio.swift in Sources */,
 				F37C2ED1256AAA4C001C3D36 /* Strings.swift in Sources */,

--- a/MultiSoundChanger/Sources/Stories/Volume/ScrollableSlider.swift
+++ b/MultiSoundChanger/Sources/Stories/Volume/ScrollableSlider.swift
@@ -1,0 +1,61 @@
+//
+//  ScrollableSlider.swift
+//
+//  Created by Nate Thompson on 10/24/17.
+//
+//  https://github.com/thompsonate/Scrollable-NSSlider
+//
+
+import Cocoa
+
+class ScrollableSlider: NSSlider {
+    override func scrollWheel(with event: NSEvent) {
+        guard self.isEnabled else {
+            return
+        }
+        
+        let range = Float(self.maxValue - self.minValue)
+        var delta = Float(0)
+        
+        // Allow horizontal scrolling on horizontal and circular sliders
+        if _isVertical && self.sliderType == .linear {
+            delta = Float(event.deltaY)
+        } else if self.userInterfaceLayoutDirection == .rightToLeft {
+            delta = Float(event.deltaY + event.deltaX)
+        } else {
+            delta = Float(event.deltaY - event.deltaX)
+        }
+        
+        // Account for natural scrolling
+        if event.isDirectionInvertedFromDevice {
+            delta *= -1
+        }
+        
+        let increment = range * delta / 100
+        var value = self.floatValue + increment
+        
+        // Wrap around if slider is circular
+        if self.sliderType == .circular {
+            let minValue = Float(self.minValue)
+            let maxValue = Float(self.maxValue)
+            
+            if value < minValue {
+                value = maxValue - abs(increment)
+            } else if value > maxValue {
+                value = minValue + abs(increment)
+            }
+        }
+        
+        self.floatValue = value
+        self.sendAction(self.action, to: self.target)
+    }
+    
+    private var _isVertical: Bool {
+        if #available(macOS 10.12, *) {
+            return self.isVertical
+        } else {
+            // isVertical is an NSInteger in versions before 10.12
+            return ((self.value(forKey: "isVertical") as? NSInteger) ?? 0) == 1
+        }
+    }
+}

--- a/MultiSoundChanger/Sources/Stories/Volume/Volume.storyboard
+++ b/MultiSoundChanger/Sources/Stories/Volume/Volume.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,7 +14,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="253" height="28"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <subviews>
-                            <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Imv-Ah-oMz">
+                            <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Imv-Ah-oMz" customClass="ScrollableSlider" customModule="MultiSoundChanger" customModuleProvider="target">
                                 <rect key="frame" x="18" y="-2" width="217" height="28"/>
                                 <sliderCell key="cell" continuous="YES" state="on" alignment="left" maxValue="100" doubleValue="50" tickMarkPosition="above" sliderType="linear" id="Prx-bs-PU2"/>
                                 <connections>


### PR DESCRIPTION
The built-in macOS volume controls have always allowed scrolling while hover over the slider to control the volume. This adds the functionality to this utility.

It even has the correct behavior of horizontal scrolling when natural scrolling is disabled, which Big Sur has broken currently. 

Leverages https://github.com/thompsonate/Scrollable-NSSlider